### PR TITLE
Allow showing the interstitial multiple times

### DIFF
--- a/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.m
+++ b/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.m
@@ -781,7 +781,6 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
 
 
 - (void)presentAd:(MobFoxAdType)advertType {
-
     switch (advertType) {
         case MobFoxAdTypeImage:
         case MobFoxAdTypeText:
@@ -810,7 +809,6 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
             }
             break;
     }
-
 }
 
 - (void)interstitialStopAdvert {
@@ -906,8 +904,6 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
     }
 
     self.advertViewActionInProgress = NO;
-    self.advertLoaded = NO;
-
 }
 
 #pragma mark - Request Status Reporting


### PR DESCRIPTION
For instance in Mini Golf Stars the interstitial can currently only shown once per app launch. The reason is an implementation difference between demo app and the integration instructions, and thus the problem haven't been visible until production apps. I think that this is a better way than always forcing to request an interstitial before each time we want to show it.
