### PR TITLE
Redesigned delegate & support for dynamic pricing

### DIFF
--- a/BuildUnity3D.sh
+++ b/BuildUnity3D.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
 XCODEBUILD=`which xcodebuild`
+UNITY_IOS_PLUGINS_PATH=build/Unity3D/Assets/Plugins/iOS
+
 if [ -z "$XCODEBUILD" ]; then
     echo "xcodebuild tool not found"
     exit 127
@@ -9,9 +14,15 @@ fi
 $XCODEBUILD -project Seeds.xcodeproj -configuration Release -target SeedsLibrary -sdk iphoneos clean build
 $XCODEBUILD -project Seeds.xcodeproj -configuration Release -target SeedsLibrary -sdk iphonesimulator clean build
 $XCODEBUILD -project Seeds.xcodeproj -configuration Release -target SeedsResources -sdk macosx clean build
-mkdir -p build/Unity3D/Assets/Plugins/iOS
-cp -a build/Release/SeedsResources.bundle build/Unity3D/Assets/Plugins/iOS
-lipo -create build/Release-iphoneos/libSeedsLibrary.a build/Release-iphonesimulator/libSeedsLibrary.a -output build/Unity3D/Assets/Plugins/iOS/libSeedsLibrary.a
-cp SDK/Seeds.h build/Unity3D/Assets/Plugins/iOS
-cp SDK/SeedsInAppMessageDelegate.h build/Unity3D/Assets/Plugins/iOS
-open build/Unity3D
+mkdir -p $UNITY_IOS_PLUGINS_PATH
+cp -a build/Release/SeedsResources.bundle $UNITY_IOS_PLUGINS_PATH
+lipo -create build/Release-iphoneos/libSeedsLibrary.a build/Release-iphonesimulator/libSeedsLibrary.a -output $UNITY_IOS_PLUGINS_PATH/libSeedsLibrary.a
+cp SDK/Seeds.h $UNITY_IOS_PLUGINS_PATH
+cp SDK/SeedsInAppMessageDelegate.h $UNITY_IOS_PLUGINS_PATH
+
+if [ "${NOT_INTERACTIVE+1}" ]; then
+  # Probably called from deploy.sh form Unity SDK
+  :
+else
+  open build/Unity3D
+fi

--- a/Demo/AppDelegate.h
+++ b/Demo/AppDelegate.h
@@ -17,6 +17,7 @@
 #define YOUR_APP_KEY @"71ac2900e9d31647d68d0ddc6f0aaf52611a612d"
 #define MESSAGE_ID_0 @"575f872a64bc1e5b0eca506f"
 #define MESSAGE_ID_1 @"5746851bb29ee753053a7c9a"
+#define IAP_KEY @"test_iap_event"
 
 //development server info
 //#define YOUR_SERVER @"https://devdash.playseeds.com"

--- a/Demo/AppDelegate.m
+++ b/Demo/AppDelegate.m
@@ -21,6 +21,9 @@
 
     [Seeds.sharedInstance start:YOUR_APP_KEY withHost:YOUR_SERVER];
 
+    [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_0];
+    [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_1];
+
     [Seeds.sharedInstance requestInAppMessageStats:^(NSString* key, int purchasesCount) {
 
     }

--- a/Demo/AppDelegate.m
+++ b/Demo/AppDelegate.m
@@ -24,11 +24,6 @@
     [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_0];
     [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_1];
 
-    [Seeds.sharedInstance requestInAppMessageStats:^(NSString* key, int purchasesCount) {
-
-    }
-                                                 of:@""];
-
     if ([launchOptions objectForKey:UIApplicationLaunchOptionsURLKey] != nil) {
         NSURL *url = [launchOptions objectForKey: UIApplicationLaunchOptionsURLKey];
         ViewController* viewController = (ViewController*)self.window.rootViewController;

--- a/Demo/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Demo/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -59,6 +59,11 @@
       "idiom" : "ipad",
       "size" : "76x76",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
     }
   ],
   "info" : {

--- a/Demo/Info-EmbeddedFramework.plist
+++ b/Demo/Info-EmbeddedFramework.plist
@@ -21,6 +21,8 @@
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
 			<key>CFBundleURLName</key>
 			<string>com.playseeds.ios$(PRODUCT_NAME:rfc1034identifier).url</string>
 			<key>CFBundleURLSchemes</key>

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -73,7 +73,6 @@
         [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_1];
 }
 
-
 - (void)handleUrl:(NSURL*)url {
     NSLog(@"url = %@", url);
     [self.urlLabel setText:[NSString stringWithFormat:@"InApp URL: %@", url]];

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -60,14 +60,14 @@
 
 - (IBAction)showIAM0:(id)sender {
     if ([Seeds.sharedInstance isInAppMessageLoaded:MESSAGE_ID_0])
-        [Seeds.sharedInstance showInAppMessage:MESSAGE_ID_0 in:self];
+        [Seeds.sharedInstance showInAppMessage:MESSAGE_ID_0 in:self withContext: @"in-demo-app"];
     else
         [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_0];
 }
 
 - (IBAction)showIAM1:(id)sender {   
     if ([Seeds.sharedInstance isInAppMessageLoaded:MESSAGE_ID_1])
-        [Seeds.sharedInstance showInAppMessage:MESSAGE_ID_1 in:self];
+        [Seeds.sharedInstance showInAppMessage:MESSAGE_ID_1 in:self withContext: @"in-demo-app"];
     else
         [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_1];
 }

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -30,6 +30,10 @@
     NSLog(@"seedsInAppMessageClicked(%@)", messageId);
 }
 
+- (void)seedsInAppMessageClicked:(NSString*)messageId withPrice:(double)price {
+    NSLog(@"seedsInAppMessageClicked(%@), price = %@", messageId, @(price));
+}
+
 - (void)seedsInAppMessageDismissed:(NSString*)messageId {
     NSLog(@"seedsInAppMessageDismissed(%@)", messageId);
 }
@@ -62,12 +66,13 @@
         [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_0];
 }
 
-- (IBAction)showIAM1:(id)sender {
+- (IBAction)showIAM1:(id)sender {   
     if ([Seeds.sharedInstance isInAppMessageLoaded:MESSAGE_ID_1])
         [Seeds.sharedInstance showInAppMessage:MESSAGE_ID_1 in:self];
     else
         [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_1];
 }
+
 
 - (void)handleUrl:(NSURL*)url {
     NSLog(@"url = %@", url);

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -26,20 +26,20 @@
     Seeds.sharedInstance.inAppMessageDelegate = self;
 }
 
-- (void)seedsInAppMessageClicked:(SeedsInAppMessage*)inAppMessage withMessageId:(NSString*)messageId {
+- (void)seedsInAppMessageClicked:(NSString*)messageId {
     NSLog(@"seedsInAppMessageClicked(%@)", messageId);
 }
 
-- (void)seedsInAppMessageClosed:(SeedsInAppMessage*)inAppMessage withMessageId:(NSString*)messageId andCompleted:(BOOL)completed {
-    NSLog(@"seedsInAppMessageClosed(%@), completed = %@", messageId, completed ? @"YES" : @"NO");
+- (void)seedsInAppMessageDismissed:(NSString*)messageId {
+    NSLog(@"seedsInAppMessageDismissed(%@)", messageId);
 }
 
-- (void)seedsInAppMessageLoadSucceeded:(SeedsInAppMessage*)inAppMessage withMessageId:(NSString*)messageId {
+- (void)seedsInAppMessageLoadSucceeded:(NSString *)messageId {
     NSLog(@"seedsInAppMessageLoadSucceeded(%@)", messageId);
     [Seeds.sharedInstance showInAppMessage:messageId in:self];
 }
 
-- (void)seedsInAppMessageShown:(SeedsInAppMessage*)inAppMessage withMessageId:(NSString*)messageId withSuccess:(BOOL)success {
+- (void)seedsInAppMessageShown:(NSString*)messageId withSuccess:(BOOL)success {
     NSLog(@"seedsInAppMessageShown(%@), success = %@", messageId, success ? @"YES" : @"NO");
 }
 
@@ -49,7 +49,6 @@
 
 - (IBAction)iapEvent:(id)sender {
     [Seeds.sharedInstance recordIAPEvent:@"ios_iap" price:0.99];
-    //[Seeds.sharedInstance trackPurchase:@"ios_iap" price:0.99];
 }
 
 - (IBAction)seedsIapEvent:(id)sender {

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -32,6 +32,7 @@
 
 - (void)seedsInAppMessageClicked:(NSString *)messageId withDynamicPrice:(double)price {
     NSLog(@"seedsInAppMessageClicked(%@), price = %@", messageId, @(price));
+    [Seeds.sharedInstance recordSeedsIAPEvent:IAP_KEY price:0.99];
 }
 
 - (void)seedsInAppMessageDismissed:(NSString*)messageId {
@@ -52,6 +53,28 @@
 
 - (IBAction)iapEvent:(id)sender {
     [Seeds.sharedInstance recordIAPEvent:@"ios_iap" price:0.99];
+
+
+    // TODO: Create a separate button for user queries
+    [Seeds.sharedInstance requestInAppMessageShowCount:^(NSString *errorMessage, int shownCount) {
+        if(errorMessage == nil)
+            NSLog(@"requestInAppMessageShowCount(%@): %i", MESSAGE_ID_0, shownCount);
+    } of: MESSAGE_ID_0];
+
+    [Seeds.sharedInstance requestTotalInAppMessageShowCount:^(NSString *errorMessage, int showCount) {
+        if(errorMessage == nil)
+            NSLog(@"requestTotalInAppMessageShowCount: %i", showCount);
+    }];
+
+    [Seeds.sharedInstance requestInAppPurchaseCount:^(NSString *errorMessage, int purchaseCount) {
+        if(errorMessage == nil)
+            NSLog(@"requestInAppPurchaseCount(%@): %i", IAP_KEY, purchaseCount);
+    } of: IAP_KEY];
+
+    [Seeds.sharedInstance requestTotalInAppPurchaseCount:^(NSString *errorMessage, int purchaseCount) {
+        if (errorMessage == nil)
+            NSLog(@"requestTotalInAppPurchaseCount: %i", purchaseCount);
+    }];
 }
 
 - (IBAction)seedsIapEvent:(id)sender {
@@ -70,13 +93,6 @@
         [Seeds.sharedInstance showInAppMessage:MESSAGE_ID_1 in:self withContext: @"in-demo-app"];
     else
         [Seeds.sharedInstance requestInAppMessage:MESSAGE_ID_1];
-}
-
-- (void)handleUrl:(NSURL*)url {
-    NSLog(@"url = %@", url);
-    [self.urlLabel setText:[NSString stringWithFormat:@"InApp URL: %@", url]];
-
-    [Seeds.sharedInstance recordSeedsIAPEvent:@"deep-link-item" price:0.99];
 }
 
 @end

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -30,7 +30,7 @@
     NSLog(@"seedsInAppMessageClicked(%@)", messageId);
 }
 
-- (void)seedsInAppMessageClicked:(NSString*)messageId withPrice:(double)price {
+- (void)seedsInAppMessageClicked:(NSString *)messageId withDynamicPrice:(double)price {
     NSLog(@"seedsInAppMessageClicked(%@), price = %@", messageId, @(price));
 }
 

--- a/Demo/ViewController.m
+++ b/Demo/ViewController.m
@@ -40,7 +40,6 @@
 
 - (void)seedsInAppMessageLoadSucceeded:(NSString *)messageId {
     NSLog(@"seedsInAppMessageLoadSucceeded(%@)", messageId);
-    [Seeds.sharedInstance showInAppMessage:messageId in:self];
 }
 
 - (void)seedsInAppMessageShown:(NSString*)messageId withSuccess:(BOOL)success {

--- a/SDK/InAppMessaging/MobFoxHTMLBannerView.h
+++ b/SDK/InAppMessaging/MobFoxHTMLBannerView.h
@@ -81,6 +81,7 @@ enum {
 @property (nonatomic, retain) NSURL *tapThroughURL;
 @property (nonatomic, retain) UIImage *bannerImage;
 @property (strong, nonatomic) NSString *requestURL;
+@property (strong, nonatomic) NSString* inferredSeedsMessageId;
 
 @property (nonatomic, assign) NSInteger userAge;
 @property (nonatomic, strong) NSString* userGender;

--- a/SDK/InAppMessaging/MobFoxHTMLBannerView.m
+++ b/SDK/InAppMessaging/MobFoxHTMLBannerView.m
@@ -366,9 +366,6 @@ NSString * const MobFoxErrorDomain = @"MobFox";
         self.skipOverlay = @"1";
     }
 
-    NSString *messageId = [json objectForKey:@"message_id"];
-    Seeds.sharedInstance.inAppMessageId = messageId;
-
     NSString *productId = [json objectForKey:@"productIdIos"];
 
     _shouldScaleWebView = NO; //[[xml.documentRoot getNamedChild:@"scale"].text isEqualToString:@"yes"];

--- a/SDK/InAppMessaging/MobFoxHTMLBannerView.m
+++ b/SDK/InAppMessaging/MobFoxHTMLBannerView.m
@@ -398,7 +398,9 @@ NSString * const MobFoxErrorDomain = @"MobFox";
         NSString *messageVariant = [json objectForKey:@"messageVariant"];
         if (messageVariant)
         {
-            Seeds.sharedInstance.inAppMessageVariantName = messageVariant;
+            // Useful for cases where the message id is not defined explicitly
+            // TODO: Refactor this out when moving to model where message is is always explicitly required
+            Seeds.sharedInstance.currentMessageId = messageVariant;
         }
 
         id doNotShowValue = [json objectForKey:@"doNotShow"];

--- a/SDK/InAppMessaging/MobFoxHTMLBannerView.m
+++ b/SDK/InAppMessaging/MobFoxHTMLBannerView.m
@@ -713,7 +713,8 @@ NSString * const MobFoxErrorDomain = @"MobFox";
                 [NSURLConnection sendAsynchronousRequest:request2 queue:[[NSOperationQueue alloc] init] completionHandler:nil];
             }
             _tapThroughURL = url;
-            [self tapThrough:nil];
+            [Seeds sharedInstance].clickUrl = _tapThroughURL;
+            [self tapThrough:nil ];
             return NO;
         } else {
             return YES;

--- a/SDK/InAppMessaging/MobFoxHTMLBannerView.m
+++ b/SDK/InAppMessaging/MobFoxHTMLBannerView.m
@@ -397,7 +397,7 @@ NSString * const MobFoxErrorDomain = @"MobFox";
         {
             // Useful for cases where the message id is not defined explicitly
             // TODO: Refactor this out when moving to model where message is is always explicitly required
-            Seeds.sharedInstance.currentMessageId = messageVariant;
+            inferredSeedsMessageId = messageVariant;
         }
 
         id doNotShowValue = [json objectForKey:@"doNotShow"];
@@ -818,6 +818,7 @@ NSString * const MobFoxErrorDomain = @"MobFox";
 @synthesize refreshAnimation;
 @synthesize refreshTimerOff;
 @synthesize requestURL;
+@synthesize inferredSeedsMessageId;
 @synthesize userAgent;
 @synthesize skipOverlay;
 @synthesize adType;

--- a/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.h
+++ b/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.h
@@ -59,7 +59,7 @@ typedef enum {
 
 - (void)mobfoxVideoInterstitialViewActionWillLeaveApplication:(MobFoxVideoInterstitialViewController *)videoInterstitial;
 
-- (void)mobfoxVideoInterstitialViewWasClicked:(MobFoxVideoInterstitialViewController *)videoInterstitial;
+- (void)mobfoxVideoInterstitialViewWasClicked:(MobFoxVideoInterstitialViewController *)videoInterstitial withUrl:(NSURL *)url;
 
 @end
 

--- a/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.h
+++ b/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.h
@@ -76,7 +76,6 @@ typedef enum {
     NSString *requestURL;
     NSString *videoRequestURL;
     UIImage *_bannerImage;
-
 }
 
 @property (nonatomic, assign) IBOutlet __unsafe_unretained id <MobFoxVideoInterstitialViewControllerDelegate> delegate;
@@ -89,6 +88,7 @@ typedef enum {
 @property (nonatomic, assign) NSInteger userAge;
 @property (nonatomic, strong) NSString* userGender;
 @property (nonatomic, retain) NSArray* keywords;
+@property (nonatomic, strong) NSString* seedsMessageId;
 
 @property (nonatomic, strong) NSString *requestURL;
 

--- a/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.m
+++ b/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.m
@@ -145,6 +145,7 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
 @synthesize interstitialURL, interstitialHoldingView, interstitialWebView, interstitialMarkup, browserBackButton, browserForwardButton;
 @synthesize userAgent;
 @synthesize userAge, userGender, keywords;
+@synthesize seedsMessageId;
 
 
 #pragma mark - Init/Dealloc Methods
@@ -665,7 +666,12 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
     bannerView.bannerImage = _bannerImage;
 
     [bannerView performSelectorOnMainThread:@selector(setupAdFromJson:) withObject:json waitUntilDone:YES];
-    
+
+    // TODO: Refactor this out when moving to model where message is is always explicitly required
+    if (seedsMessageId == nil) {
+        seedsMessageId = bannerView.inferredSeedsMessageId;
+    }
+
     [self.interstitialHoldingView addSubview:bannerView];
 
     interstitialSkipButtonShow = YES;

--- a/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.m
+++ b/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.m
@@ -760,9 +760,9 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
 
 - (void)customEventFullscreenWillLeaveApplication
 {
-    if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:)])
+    if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:withUrl:)])
     {
-        [delegate mobfoxVideoInterstitialViewWasClicked:self];
+        [delegate mobfoxVideoInterstitialViewWasClicked:self withUrl:nil];
     }
 
     if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewActionWillLeaveApplication:)])
@@ -1082,9 +1082,9 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
 
 	if (tapThroughLeavesApp || [tapThroughURL isDeviceSupported])
 	{
-        if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:)])
+        if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:withUrl:)])
         {
-            [delegate mobfoxVideoInterstitialViewWasClicked:self];
+            [delegate mobfoxVideoInterstitialViewWasClicked:self withUrl:nil];
         }
 
         if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewActionWillLeaveApplication:)])
@@ -1253,8 +1253,11 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
     [self interstitialStopAdvert];
 
     id<SeedsInAppMessageDelegate> seedsDelegate = Seeds.sharedInstance.inAppMessageDelegate;
-    if (seedsDelegate && [seedsDelegate respondsToSelector:@selector(seedsInAppMessageClosed:withMessageId:andCompleted:)])
-        [seedsDelegate seedsInAppMessageClosed:nil withMessageId:requestedMessageId andCompleted:NO];
+    if (seedsDelegate && [seedsDelegate respondsToSelector:@selector(seedsInAppMessageDismissed:)])
+        [seedsDelegate seedsInAppMessageDismissed:requestedMessageId];
+    
+    if (seedsDelegate && [seedsDelegate respondsToSelector:@selector(seedsInAppMessageDismissed)])
+        [seedsDelegate seedsInAppMessageDismissed];
 }
 
 #pragma mark -
@@ -1370,13 +1373,14 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
         
         [self checkAndCancelAutoClose];
         if(_overlayClickThrough) {
-            if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:)])
-            {
-                [delegate mobfoxVideoInterstitialViewWasClicked:self];
-            }
-            [self advertActionTrackingEvent:@"overlayClick"];
             NSString *escapedDataString = [_overlayClickThrough stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
             NSURL *clickUrl = [NSURL URLWithString:escapedDataString];
+            
+            if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:withUrl:)])
+            {
+                [delegate mobfoxVideoInterstitialViewWasClicked:self withUrl: clickUrl];
+            }
+            [self advertActionTrackingEvent:@"overlayClick"];
             [self tapThrough:YES tapThroughURL:clickUrl];
         }
     }
@@ -1388,9 +1392,9 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
 
         if(_videoClickThrough) {
             [self advertActionTrackingEvent:@"videoClick"];
-            if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:)])
+            if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:withUrl:)])
             {
-                [delegate mobfoxVideoInterstitialViewWasClicked:self];
+                [delegate mobfoxVideoInterstitialViewWasClicked:self withUrl:nil];
             }
             NSString *escapedDataString = [_videoClickThrough stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
             NSURL *clickUrl = [NSURL URLWithString:escapedDataString];
@@ -1542,16 +1546,16 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
 #pragma mark Banner View Delegate
 
 -(void) mobfoxHTMLBannerViewActionWillPresent:(MobFoxHTMLBannerView *)banner {
-    if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:)])
+    if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:withUrl:)])
     {
-        [delegate mobfoxVideoInterstitialViewWasClicked:self];
+        [delegate mobfoxVideoInterstitialViewWasClicked:self withUrl:nil];
     }
 }
 
 -(void) mobfoxHTMLBannerViewActionWillLeaveApplication:(MobFoxHTMLBannerView *)banner {
-    if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:)])
+    if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewWasClicked:withUrl:)])
     {
-        [delegate mobfoxVideoInterstitialViewWasClicked:self];
+        [delegate mobfoxVideoInterstitialViewWasClicked:self withUrl:[Seeds sharedInstance].clickUrl];
     }
 
     if ([delegate respondsToSelector:@selector(mobfoxVideoInterstitialViewActionWillLeaveApplication:)])

--- a/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.m
+++ b/SDK/InAppMessaging/MobFoxVideoInterstitialViewController.m
@@ -49,7 +49,6 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
     BOOL alreadyRequestedInterstitial;
 
     UIInterfaceOrientation requestedAdOrientation;
-    NSString* requestedMessageId;
     
     BOOL currentlyPlayingInterstitial;
     float statusBarHeight;
@@ -440,7 +439,7 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
 {
     if (!self.advertLoaded)
         return NO;
-    return messageId == nil || [messageId isEqualToString:requestedMessageId];
+    return messageId == nil || [messageId isEqualToString:seedsMessageId];
 }
 
 - (void)requestAd:(NSString*)messageId
@@ -503,8 +502,6 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
     alreadyRequestedInterstitial = YES;
 	@autoreleasepool
 	{
-        requestedMessageId = messageId;
-
         UIInterfaceOrientation interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
         requestedAdOrientation = interfaceOrientation;
         NSString *orientation = UIInterfaceOrientationIsPortrait(interfaceOrientation) ? @"portrait" : @"landscape";
@@ -1260,7 +1257,7 @@ NSString * const MobFoxVideoInterstitialErrorDomain = @"MobFoxVideoInterstitial"
 
     id<SeedsInAppMessageDelegate> seedsDelegate = Seeds.sharedInstance.inAppMessageDelegate;
     if (seedsDelegate && [seedsDelegate respondsToSelector:@selector(seedsInAppMessageDismissed:)])
-        [seedsDelegate seedsInAppMessageDismissed:requestedMessageId];
+        [seedsDelegate seedsInAppMessageDismissed:seedsMessageId];
     
     if (seedsDelegate && [seedsDelegate respondsToSelector:@selector(seedsInAppMessageDismissed)])
         [seedsDelegate seedsInAppMessageDismissed];

--- a/SDK/Seeds.h
+++ b/SDK/Seeds.h
@@ -74,17 +74,10 @@ extern NSString* const kCLYUserCustom;
 
 - (void)recordSeedsIAPEvent:(NSString *)key price:(double)price;
 
-- (void)trackPurchase:(NSString *)key price:(double)price;
-
-- (void)requestInAppMessage;
 - (void)requestInAppMessage:(NSString*)messageId;
 
-- (BOOL)isInAppMessageLoaded;
 - (BOOL)isInAppMessageLoaded:(NSString*)messageId;
 
-- (void)showInAppMessageIn:(UIViewController*)viewController;
-- (void)showInAppMessageIn:(UIViewController*)viewController withContext:(NSString*)messageContext;
-- (void)showInAppMessage:(NSString*)messageId in:(UIViewController*)viewController;
 - (void)showInAppMessage:(NSString*)messageId in:(UIViewController*)viewController withContext:(NSString*)messageContext;
 
 #pragma mark - Seeds Statistics

--- a/SDK/Seeds.h
+++ b/SDK/Seeds.h
@@ -37,7 +37,6 @@
 @property (atomic, assign) BOOL inAppMessageDoNotShow;
 @property (atomic, assign) BOOL adClicked;
 @property (atomic, assign) NSURL* clickUrl;
-@property (atomic, copy) NSString* currentMessageId;
 
 + (instancetype)sharedInstance;
 

--- a/SDK/Seeds.h
+++ b/SDK/Seeds.h
@@ -38,7 +38,7 @@
 @property (atomic, assign) BOOL inAppMessageDoNotShow;
 @property (atomic, assign) BOOL adClicked;
 @property (atomic, assign) NSURL* clickUrl;
-@property (atomic, copy) NSString* inAppMessageVariantName;
+@property (atomic, copy) NSString* currentMessageId;
 
 + (instancetype)sharedInstance;
 

--- a/SDK/Seeds.h
+++ b/SDK/Seeds.h
@@ -82,13 +82,16 @@ extern NSString* const kCLYUserCustom;
 
 #pragma mark - Seeds Statistics
 
-typedef void (^ SeedsInAppPurchaseStatsCallback)(NSString* key, int purchasesCount);
-- (void)requestInAppPurchaseCount:(SeedsInAppPurchaseStatsCallback)callback of:(NSString*)key;
-- (void)requestInAppPurchasesCount:(SeedsInAppPurchaseStatsCallback)callback;
+typedef void (^ SeedsInAppPurchaseCountCallback)(NSString* errorMessage, int purchasesCount);
+- (void)requestInAppPurchaseCount:(SeedsInAppPurchaseCountCallback)callback of:(NSString*)key;
+- (void)requestTotalInAppPurchaseCount:(SeedsInAppPurchaseCountCallback)callback;
 
-typedef void (^ SeedsInAppMessageStatsCallback)(NSString* messageId, int shownCount);
-- (void)requestInAppMessageStats:(SeedsInAppMessageStatsCallback)callback;
-- (void)requestInAppMessageStats:(SeedsInAppMessageStatsCallback)callback of:(NSString*)messageId;
+typedef void (^ SeedsInAppMessageShowCountCallback)(NSString* errorMessage, int showCount);
+- (void)requestTotalInAppMessageShowCount:(SeedsInAppMessageShowCountCallback)callback;
+- (void)requestInAppMessageShowCount:(SeedsInAppMessageShowCountCallback)callback of:(NSString*)messageId;
+
+typedef void (^ SeedsGenericUserBehaviorQueryCallback)(NSString* errorMessage, id result);
+- (void)requestGenericUserBehaviorQuery:(SeedsGenericUserBehaviorQueryCallback)callback of:(NSString*)queryPath;
 
 #pragma mark - Seeds Messaging
 #if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR) && (!SEEDS_TARGET_WATCHKIT)

--- a/SDK/Seeds.h
+++ b/SDK/Seeds.h
@@ -33,7 +33,6 @@
 @property (nonatomic, copy) NSString* deviceId;
 @property (atomic, retain) id<SeedsInAppMessageDelegate> inAppMessageDelegate;
 
-@property (atomic, copy) NSString* inAppMessageId;
 @property (atomic, copy) NSString* inAppMessageContext;
 @property (atomic, assign) BOOL inAppMessageDoNotShow;
 @property (atomic, assign) BOOL adClicked;

--- a/SDK/Seeds.h
+++ b/SDK/Seeds.h
@@ -37,6 +37,7 @@
 @property (atomic, copy) NSString* inAppMessageContext;
 @property (atomic, assign) BOOL inAppMessageDoNotShow;
 @property (atomic, assign) BOOL adClicked;
+@property (atomic, assign) NSURL* clickUrl;
 @property (atomic, copy) NSString* inAppMessageVariantName;
 
 + (instancetype)sharedInstance;

--- a/SDK/Seeds.m
+++ b/SDK/Seeds.m
@@ -110,6 +110,7 @@
         self.inAppMessageVariantName = nil;
         self.inAppMessageDoNotShow = NO;
         self.adClicked = NO;
+        self.clickUrl = nil;
     }
     return self;
 }

--- a/SDK/Seeds.m
+++ b/SDK/Seeds.m
@@ -106,7 +106,6 @@
         
         self.deviceId = nil;
         self.inAppMessageContext = nil;
-        self.currentMessageId = nil;
         self.inAppMessageDoNotShow = NO;
         self.adClicked = NO;
         self.clickUrl = nil;
@@ -287,13 +286,9 @@
 - (void)recordGenericIAPEvent:(NSString *)key price:(double)price isSeedsEvent:(BOOL)isSeedsEvent
 {
     NSMutableDictionary *segmentation = [[NSMutableDictionary alloc] init];
-    
-    //[segmentation setObject:isSeedsEvent ? @"Seeds" : @"Non-Seeds" forKey:@"IAP type"];
+
     if (isSeedsEvent) {
         [segmentation setObject:@"Seeds" forKey:@"IAP type"];
-        if (self.currentMessageId) {
-            [segmentation setObject:self.currentMessageId forKey:@"message"];
-        }
     } else {
         [segmentation setObject:@"Non-Seeds" forKey:@"IAP type"];
     }

--- a/SDK/Seeds.m
+++ b/SDK/Seeds.m
@@ -347,7 +347,7 @@
 
 - (void)showInAppMessageIn:(UIViewController*)viewController;
 {
-    [[SeedsInterstitialAds sharedInstance] showInAppMessage:nil in:viewController withContext:nil];
+    [[SeedsInterstitialAds sharedInstance] showInAppMessage:nil in:viewController withContext:@""];
 }
 
 - (void)showInAppMessageIn:(UIViewController*)viewController withContext:(NSString*)messageContext;
@@ -357,7 +357,7 @@
 
 - (void)showInAppMessage:(NSString*)messageId in:(UIViewController*)viewController;
 {
-    [[SeedsInterstitialAds sharedInstance] showInAppMessage:messageId in:viewController withContext:nil];
+    [[SeedsInterstitialAds sharedInstance] showInAppMessage:messageId in:viewController withContext:@""];
 }
 
 - (void)showInAppMessage:(NSString*)messageId in:(UIViewController*)viewController withContext:(NSString*)messageContext;

--- a/SDK/Seeds.m
+++ b/SDK/Seeds.m
@@ -348,7 +348,7 @@
 
 - (void)showInAppMessageIn:(UIViewController*)viewController;
 {
-    [[SeedsInterstitialAds sharedInstance] showInAppMessage:nil in:viewController withContext:@""];
+    [[SeedsInterstitialAds sharedInstance] showInAppMessage:nil in:viewController withContext:nil];
 }
 
 - (void)showInAppMessageIn:(UIViewController*)viewController withContext:(NSString*)messageContext;
@@ -358,7 +358,7 @@
 
 - (void)showInAppMessage:(NSString*)messageId in:(UIViewController*)viewController;
 {
-    [[SeedsInterstitialAds sharedInstance] showInAppMessage:messageId in:viewController withContext:@""];
+    [[SeedsInterstitialAds sharedInstance] showInAppMessage:messageId in:viewController withContext:nil];
 }
 
 - (void)showInAppMessage:(NSString*)messageId in:(UIViewController*)viewController withContext:(NSString*)messageContext;

--- a/SDK/Seeds.m
+++ b/SDK/Seeds.m
@@ -105,7 +105,6 @@
 #endif
         
         self.deviceId = nil;
-        self.inAppMessageId = nil;
         self.inAppMessageContext = nil;
         self.currentMessageId = nil;
         self.inAppMessageDoNotShow = NO;

--- a/SDK/Seeds.m
+++ b/SDK/Seeds.m
@@ -305,9 +305,7 @@
 
 - (void) trackPurchase:(NSString *)key price:(double)price
 {
-    
     NSLog(@"[Seeds] trackPurchase start %@", Seeds.sharedInstance.adClicked ? @"YES" : @"NO");
-    
     
     if (Seeds.sharedInstance.adClicked) {
         [self recordSeedsIAPEvent:key price:price];

--- a/SDK/Seeds.m
+++ b/SDK/Seeds.m
@@ -298,18 +298,6 @@
     [self recordEvent:[@"IAP:" stringByAppendingString:key] segmentation:segmentation count:1 sum:price];
 }
 
-- (void) trackPurchase:(NSString *)key price:(double)price
-{
-    NSLog(@"[Seeds] trackPurchase start %@", Seeds.sharedInstance.adClicked ? @"YES" : @"NO");
-    
-    if (Seeds.sharedInstance.adClicked) {
-        [self recordSeedsIAPEvent:key price:price];
-        Seeds.sharedInstance.adClicked = NO;
-    } else {
-        [self recordIAPEvent:key price:price];
-    }
-}
-
 - (void)recordIAPEvent:(NSString *)key price:(double)price
 {
     [self recordGenericIAPEvent:key price:price isSeedsEvent:NO];
@@ -320,39 +308,14 @@
     [self recordGenericIAPEvent:key price:price isSeedsEvent:YES];
 }
 
-- (void)requestInAppMessage
-{
-    [self requestInAppMessage:nil];
-}
-
 - (void)requestInAppMessage:(NSString*)messageId
 {
     [[SeedsInterstitialAds sharedInstance] requestInAppMessage:messageId];
 }
 
-- (BOOL)isInAppMessageLoaded
-{
-    return [[SeedsInterstitialAds sharedInstance] isInAppMessageLoaded:nil];
-}
-
 - (BOOL)isInAppMessageLoaded:(NSString*)messageId
 {
     return [[SeedsInterstitialAds sharedInstance] isInAppMessageLoaded:messageId];
-}
-
-- (void)showInAppMessageIn:(UIViewController*)viewController;
-{
-    [[SeedsInterstitialAds sharedInstance] showInAppMessage:nil in:viewController withContext:nil];
-}
-
-- (void)showInAppMessageIn:(UIViewController*)viewController withContext:(NSString*)messageContext;
-{
-    [[SeedsInterstitialAds sharedInstance] showInAppMessage:nil in:viewController withContext:messageContext];
-}
-
-- (void)showInAppMessage:(NSString*)messageId in:(UIViewController*)viewController;
-{
-    [[SeedsInterstitialAds sharedInstance] showInAppMessage:messageId in:viewController withContext:nil];
 }
 
 - (void)showInAppMessage:(NSString*)messageId in:(UIViewController*)viewController withContext:(NSString*)messageContext;

--- a/SDK/Seeds.m
+++ b/SDK/Seeds.m
@@ -107,7 +107,7 @@
         self.deviceId = nil;
         self.inAppMessageId = nil;
         self.inAppMessageContext = nil;
-        self.inAppMessageVariantName = nil;
+        self.currentMessageId = nil;
         self.inAppMessageDoNotShow = NO;
         self.adClicked = NO;
         self.clickUrl = nil;
@@ -292,8 +292,8 @@
     //[segmentation setObject:isSeedsEvent ? @"Seeds" : @"Non-Seeds" forKey:@"IAP type"];
     if (isSeedsEvent) {
         [segmentation setObject:@"Seeds" forKey:@"IAP type"];
-        if (self.inAppMessageVariantName) {
-            [segmentation setObject:self.inAppMessageVariantName forKey:@"message"];
+        if (self.currentMessageId) {
+            [segmentation setObject:self.currentMessageId forKey:@"message"];
         }
     } else {
         [segmentation setObject:@"Non-Seeds" forKey:@"IAP type"];

--- a/SDK/SeedsInAppMessageDelegate.h
+++ b/SDK/SeedsInAppMessageDelegate.h
@@ -30,7 +30,7 @@
 - (void)seedsInAppMessageDismissed:(NSString*)messageId;
 
 // Callback signatures for an app with multiple interstitials with dynamic pricing
-- (void)seedsInAppMessageClicked:(NSString*)messageId withPrice:(double)price;
+- (void)seedsInAppMessageClicked:(NSString *)messageId withDynamicPrice:(double)price;
 
 @end
 

--- a/SDK/SeedsInAppMessageDelegate.h
+++ b/SDK/SeedsInAppMessageDelegate.h
@@ -29,6 +29,9 @@
 - (void)seedsInAppMessageClicked:(NSString*)messageId;
 - (void)seedsInAppMessageDismissed:(NSString*)messageId;
 
+// Callback signatures for an app with multiple interstitials with dynamic pricing
+- (void)seedsInAppMessageClicked:(NSString*)messageId withPrice:(double)price;
+
 @end
 
 #endif

--- a/SDK/SeedsInAppMessageDelegate.h
+++ b/SDK/SeedsInAppMessageDelegate.h
@@ -16,18 +16,18 @@
 @optional
 
 // Callback signatures for an app with a single interstitial
-- (void)seedsInAppMessageClicked:(SeedsInAppMessage*)inAppMessage;
-- (void)seedsInAppMessageClosed:(SeedsInAppMessage*)inAppMessage andCompleted:(BOOL)completed;
-- (void)seedsInAppMessageLoadSucceeded:(SeedsInAppMessage*)inAppMessage;
-- (void)seedsInAppMessageShown:(SeedsInAppMessage*)inAppMessage withSuccess:(BOOL)success;
+- (void)seedsInAppMessageLoadSucceeded;
+- (void)seedsInAppMessageShown:(BOOL)success;
 - (void)seedsNoInAppMessageFound;
+- (void)seedsInAppMessageClicked;
+- (void)seedsInAppMessageDismissed;
 
 // Callback signatures for an app with multiple interstitials
-- (void)seedsInAppMessageClicked:(SeedsInAppMessage*)inAppMessage withMessageId:(NSString*)messageId;
-- (void)seedsInAppMessageClosed:(SeedsInAppMessage*)inAppMessage withMessageId:(NSString*)messageId andCompleted:(BOOL)completed;
-- (void)seedsInAppMessageLoadSucceeded:(SeedsInAppMessage*)inAppMessage withMessageId:(NSString*)messageId;
-- (void)seedsInAppMessageShown:(SeedsInAppMessage*)inAppMessage withMessageId:(NSString*)messageId withSuccess:(BOOL)success;
+- (void)seedsInAppMessageLoadSucceeded:(NSString*)messageId;
+- (void)seedsInAppMessageShown:(NSString*)messageId withSuccess:(BOOL)success;
 - (void)seedsNoInAppMessageFound:(NSString*)messageId;
+- (void)seedsInAppMessageClicked:(NSString*)messageId;
+- (void)seedsInAppMessageDismissed:(NSString*)messageId;
 
 @end
 

--- a/SDK/SeedsInterstitialAds.h
+++ b/SDK/SeedsInterstitialAds.h
@@ -11,7 +11,7 @@
 
 @property (nonatomic, copy) NSString *appKey;
 @property (nonatomic, copy) NSString *appHost;
-@property (nonatomic, retain) MobFoxVideoInterstitialViewController *controller;
+@property (nonatomic, retain) NSMutableDictionary<NSString *, MobFoxVideoInterstitialViewController *> *interstitialsByMessageId;
 
 + (instancetype)sharedInstance;
 - (void)requestInAppMessage:(NSString*)messageId;

--- a/SDK/SeedsInterstitialAds.m
+++ b/SDK/SeedsInterstitialAds.m
@@ -175,13 +175,13 @@
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClicked)])
         [delegate seedsInAppMessageClicked];
 
-    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClicked: withPrice:)]) {
+    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClicked:withDynamicPrice:)]) {
         // Interpret the price from the link url
         NSString* path = [url path];
         bool isPriceUrl = [[url path] hasPrefix:@"/price"];
         if (isPriceUrl) {
             float price = [[url lastPathComponent] floatValue];
-            [delegate seedsInAppMessageClicked:Seeds.sharedInstance.inAppMessageId withPrice:price];
+            [delegate seedsInAppMessageClicked:Seeds.sharedInstance.inAppMessageId withDynamicPrice:price];
         }
 
     }

--- a/SDK/SeedsInterstitialAds.m
+++ b/SDK/SeedsInterstitialAds.m
@@ -70,7 +70,7 @@
     if (![self isInAppMessageLoaded:messageId] || Seeds.sharedInstance.inAppMessageDoNotShow) {
         id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
         if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:withSuccess:)])
-            [delegate seedsInAppMessageShown:Seeds.sharedInstance.inAppMessageId withSuccess:NO];
+            [delegate seedsInAppMessageShown:Seeds.sharedInstance.currentMessageId withSuccess:NO];
 
         if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:)])
             [delegate seedsInAppMessageShown:NO];
@@ -107,7 +107,7 @@
     
     id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageLoadSucceeded:)])
-        [delegate seedsInAppMessageLoadSucceeded:Seeds.sharedInstance.inAppMessageId];
+        [delegate seedsInAppMessageLoadSucceeded:Seeds.sharedInstance.currentMessageId];
 
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageLoadSucceeded)])
         [delegate seedsInAppMessageLoadSucceeded];
@@ -121,7 +121,7 @@
     
     id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
     if (delegate && [delegate respondsToSelector:@selector(seedsNoInAppMessageFound:)])
-        [delegate seedsNoInAppMessageFound:Seeds.sharedInstance.inAppMessageId];
+        [delegate seedsNoInAppMessageFound:Seeds.sharedInstance.currentMessageId];
 
     if (delegate && [delegate respondsToSelector:@selector(seedsNoInAppMessageFound)])
         [delegate seedsNoInAppMessageFound];
@@ -138,7 +138,7 @@
     
     id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:withSuccess:)])
-        [delegate seedsInAppMessageShown:Seeds.sharedInstance.inAppMessageId withSuccess:YES];
+        [delegate seedsInAppMessageShown:Seeds.sharedInstance.currentMessageId withSuccess:YES];
     
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:)])
         [delegate seedsInAppMessageShown:YES];
@@ -168,7 +168,7 @@
     
     if (!Seeds.sharedInstance.adClicked) {
         if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageDismissed:)])
-            [delegate seedsInAppMessageDismissed:Seeds.sharedInstance.inAppMessageId];
+            [delegate seedsInAppMessageDismissed:Seeds.sharedInstance.currentMessageId];
         
         if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageDismissed)])
             [delegate seedsInAppMessageDismissed:nil];
@@ -190,7 +190,7 @@
     id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
     
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClicked:)])
-        [delegate seedsInAppMessageClicked:Seeds.sharedInstance.inAppMessageId];
+        [delegate seedsInAppMessageClicked:Seeds.sharedInstance.currentMessageId];
 
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClicked)])
         [delegate seedsInAppMessageClicked];
@@ -200,7 +200,7 @@
         bool isPriceUrl = [[url path] hasPrefix:@"/price"];
         if (isPriceUrl) {
             float price = [[url lastPathComponent] floatValue];
-            [delegate seedsInAppMessageClicked:Seeds.sharedInstance.inAppMessageId withDynamicPrice:price];
+            [delegate seedsInAppMessageClicked:Seeds.sharedInstance.currentMessageId withDynamicPrice:price];
         }
 
     }

--- a/SDK/SeedsInterstitialAds.m
+++ b/SDK/SeedsInterstitialAds.m
@@ -54,14 +54,16 @@
 {
     if (![self isInAppMessageLoaded:messageId] || Seeds.sharedInstance.inAppMessageDoNotShow) {
         id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
-        if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:withMessageId:withSuccess:)])
-            [delegate seedsInAppMessageShown:nil withMessageId:Seeds.sharedInstance.inAppMessageId withSuccess:NO];
-
         if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:withSuccess:)])
-            [delegate seedsInAppMessageShown:nil withSuccess:NO];
+            [delegate seedsInAppMessageShown:Seeds.sharedInstance.inAppMessageId withSuccess:NO];
+
+        if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:)])
+            [delegate seedsInAppMessageShown:NO];
 
         return;
     }
+    
+    Seeds.sharedInstance.adClicked = NO;
     
     [viewController.view addSubview:self.controller.view];
     [viewController addChildViewController:self.controller];
@@ -82,12 +84,11 @@
     Seeds.sharedInstance.adClicked = NO;
     
     id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
-    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageLoadSucceeded:withMessageId:)])
-        [delegate seedsInAppMessageLoadSucceeded:nil withMessageId:Seeds.sharedInstance.inAppMessageId];
-    
-
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageLoadSucceeded:)])
-        [delegate seedsInAppMessageLoadSucceeded:nil];
+        [delegate seedsInAppMessageLoadSucceeded:Seeds.sharedInstance.inAppMessageId];
+
+    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageLoadSucceeded)])
+        [delegate seedsInAppMessageLoadSucceeded];
     
 }
 
@@ -114,11 +115,11 @@
                                 count:1];
     
     id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
-    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:withMessageId:withSuccess:)])
-        [delegate seedsInAppMessageShown:nil withMessageId:Seeds.sharedInstance.inAppMessageId withSuccess:YES];
-    
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:withSuccess:)])
-        [delegate seedsInAppMessageShown:nil withSuccess:YES];
+        [delegate seedsInAppMessageShown:Seeds.sharedInstance.inAppMessageId withSuccess:YES];
+    
+    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageShown:)])
+        [delegate seedsInAppMessageShown:YES];
     
 }
 
@@ -142,12 +143,14 @@
     [self.controller interstitialStopAdvert];
     
     id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
-    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClosed:withMessageId:andCompleted:)])
-        [delegate seedsInAppMessageClosed:nil withMessageId:Seeds.sharedInstance.inAppMessageId andCompleted:YES];
     
-    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClosed:andCompleted:)])
-        [delegate seedsInAppMessageClosed:nil andCompleted:YES];
-    
+    if (!Seeds.sharedInstance.adClicked) {
+        if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageDismissed:)])
+            [delegate seedsInAppMessageDismissed:Seeds.sharedInstance.inAppMessageId];
+        
+        if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageDismissed)])
+            [delegate seedsInAppMessageDismissed:nil];
+    }
 }
 
 - (void)mobfoxVideoInterstitialViewWasClicked:(MobFoxVideoInterstitialViewController *)videoInterstitial
@@ -164,11 +167,15 @@
     NSLog(@"[Seeds] mobfoxVideoInterstitialViewWasClicked (ad clicked = %s)", Seeds.sharedInstance.adClicked ? "yes" : "no");
     
     id<SeedsInAppMessageDelegate> delegate = Seeds.sharedInstance.inAppMessageDelegate;
-    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClicked:withMessageId:)])
-        [delegate seedsInAppMessageClicked:nil withMessageId:Seeds.sharedInstance.inAppMessageId];
-
+    
+    // TODO: Test this with links which lead nowhere (= do not open other application)
+    // TODO: Could the selector also include the url of the link? For the subscription feature.
+    
     if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClicked:)])
-        [delegate seedsInAppMessageClicked:nil];
+        [delegate seedsInAppMessageClicked:Seeds.sharedInstance.inAppMessageId];
+
+    if (delegate && [delegate respondsToSelector:@selector(seedsInAppMessageClicked)])
+        [delegate seedsInAppMessageClicked];
 }
 
 @end

--- a/SDK/SeedsInterstitialAds.m
+++ b/SDK/SeedsInterstitialAds.m
@@ -69,7 +69,7 @@
     [viewController.view addSubview:self.controller.view];
     [viewController addChildViewController:self.controller];
 
-    Seeds.sharedInstance.inAppMessageContext = messageContext;
+    Seeds.sharedInstance.inAppMessageContext = messageContext != nil ? messageContext : @"";
     [self.controller presentAd:MobFoxAdTypeText];
 }
 
@@ -110,7 +110,7 @@
 - (void)mobfoxVideoInterstitialViewActionWillPresentScreen:(MobFoxVideoInterstitialViewController *)videoInterstitial
 {
     NSLog(@"[Seeds] mobfoxVideoInterstitialViewActionWillPresentScreen");
-    
+
     [Seeds.sharedInstance recordEvent:@"message shown"
                          segmentation:@{ @"message" : Seeds.sharedInstance.inAppMessageVariantName,
                                          @"context" : Seeds.sharedInstance.inAppMessageContext }

--- a/Seeds.xcodeproj/project.pbxproj
+++ b/Seeds.xcodeproj/project.pbxproj
@@ -677,6 +677,7 @@
 					};
 					8A5083D61B7CAE0700A6CF52 = {
 						CreatedOnToolsVersion = 6.4;
+						DevelopmentTeam = 7Q7ARX399G;
 					};
 					8AC3B8F11B834C380059D3CA = {
 						CreatedOnToolsVersion = 6.4;
@@ -1202,6 +1203,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1230,6 +1232,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.playseeds.ios$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1253,6 +1256,7 @@
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -1274,6 +1278,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.playseeds.ios$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;

--- a/Tests/SeedsInterstitialAdsTest.m
+++ b/Tests/SeedsInterstitialAdsTest.m
@@ -80,8 +80,8 @@ MobFoxVideoInterstitialViewController *mockVideoController;
 }
 
 - (void) testMobfoxVideoInterstitialViewWasClicked {
-    [seedsInterstitialAdsMock mobfoxVideoInterstitialViewWasClicked:mockVideoController];
-    OCMVerify([seedsInterstitialAdsMock mobfoxVideoInterstitialViewWasClicked:mockVideoController]);
+    [seedsInterstitialAdsMock mobfoxVideoInterstitialViewWasClicked:mockVideoController withUrl:nil];
+    OCMVerify([seedsInterstitialAdsMock mobfoxVideoInterstitialViewWasClicked:mockVideoController withUrl:nil]);
 }
 
 //- (void)testPerformanceExample {

--- a/Tests/SeedsSDK_Tests.m
+++ b/Tests/SeedsSDK_Tests.m
@@ -47,7 +47,7 @@
 
     [Seeds sharedInstance].inAppMessageDelegate = self;
     _testVC = OCMClassMock([UIViewController class]);
-    Seeds.sharedInstance.inAppMessageVariantName = @"testVariantName";
+    Seeds.sharedInstance.currentMessageId = @"testVariantName";
     
 }
 


### PR DESCRIPTION
- Simplified & redesigned the delegate callbacks: 
  - Obsolete `SeedsInAppMessage` is removed everywhere
  - Now the `seedsInAppMessageClosed` callback is replaced with a `seedsInAppMessageDismissed` callback, which functions as it says: it's invoked only when a close button or interstitial background is touched and the interstitial is dismissed.
- Added intitial support for dynamic pricing with `- (void)seedsInAppMessageClicked:(NSString*)messageId withPrice:(double)price` callback, which interprets the price from a link following `something-here://seeds/price/1.00` format
- Basically also removed need for deep linking with these updates because `seedsInAppMessageClicked` is all you need 

🆒🆒 
